### PR TITLE
Changing hmac object to take raw secret value as its key.

### DIFF
--- a/src/pubsubhubbub.js
+++ b/src/pubsubhubbub.js
@@ -343,7 +343,7 @@ PubSubHubbub.prototype._onPostRequest = function(req, res, next) {
         signature = (signatureParts.pop() || '').toLowerCase();
 
         try {
-            hmac = crypto.createHmac(algo, crypto.createHmac('sha1', this.secret).update(topic).digest('hex'));
+            hmac = crypto.createHmac(algo, this.secret);
         } catch (E) {
             return this._sendError(req, res, next, 403, 'Forbidden');
         }

--- a/test/pubsubhubbub-test.js
+++ b/test/pubsubhubbub-test.js
@@ -13,10 +13,8 @@ var pubsub = pubSubHubbub.createServer({
 	sendImmediately: true
 });
 
-var topic = 'http://test.com';
 var response_body = 'This is a response.';
-var encrypted_secret = crypto.createHmac('sha1', pubsub.secret).update(topic).digest('hex');
-var hub_encryption = crypto.createHmac('sha1', encrypted_secret).update(response_body).digest('hex');
+var hub_encryption = crypto.createHmac('sha1', pubsub.secret).update(response_body).digest('hex');
 
 describe('pubsubhubbub notification', function() {
 	beforeEach(function() {


### PR DESCRIPTION
Hi there. Not sure if the protocol has been changed/updated since this piece of code was last looked at, but it wasn't working correctly as defined in version 0.4 of the protocol:

http://pubsubhubbub.github.io/PubSubHubbub/pubsubhubbub-core-0.4.html#rfc.section.8

In case anybody looks at this in the future:

After consuming the request body, the hmac object would generate a hash value that would never match the one computed from the hub (superfeedr, in my case) because the original line of code used a hash variation of the secret value as HMAC's key. HMAC should be using the plain text secret value as its key (at least, as of PuSH protocol v0.4)