### PR TITLE
Fix link rels without quotation marks not being detected

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pubsubhubbub",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "PubSubHubbub subscriber",
   "main": "src/pubsubhubbub.js",
   "scripts": {

--- a/src/pubsubhubbub.js
+++ b/src/pubsubhubbub.js
@@ -326,10 +326,10 @@ PubSubHubbub.prototype._onPostRequest = function(req, res, next) {
                 hub = url;
                 break;
         }
-    };
+    }
 
     // v0.4 hubs have a link header that includes both the topic url and hub url
-    var regex = /<([^>]+)>;\s*rel=(?:["'](?=.*["']))?([A-z]+)/gi
+    var regex = /<([^>]+)>;\s*rel=(?:["'](?=.*["']))?([A-z]+)/gi;
     var requestLink = req.headers && req.headers.link || "";
     var requestRels = regex.exec(requestLink);
 

--- a/src/pubsubhubbub.js
+++ b/src/pubsubhubbub.js
@@ -315,18 +315,25 @@ PubSubHubbub.prototype._onPostRequest = function(req, res, next) {
         tooLarge = false,
         signatureParts, algo, signature, hmac;
 
-    // v0.4 hubs have a link header that includes both the topic url and hub url
-    (req.headers && req.headers.link || '').
-    replace(/<([^>]+)>\s*(?:;\s*rel=["']([^"']+)["'])?/gi, function(o, url, rel) {
-        switch ((rel || '').toLowerCase()) {
-            case 'self':
+    function setTopicHub(o, url, rel) {
+        rel = rel || "";
+
+        switch(rel.toLowerCase()){
+            case "self":
                 topic = url;
                 break;
-            case 'hub':
+            case "hub":
                 hub = url;
                 break;
         }
-    });
+    };
+
+    // v0.4 hubs have a link header that includes both the topic url and hub url
+    var regex = /<([^>]+)>;\s*rel=(?:["'](?=.*["']))?([A-z]+)/gi
+    var requestLink = req.headers && req.headers.link || "";
+    var requestRels = regex.exec(requestLink);
+
+    setTopicHub.apply(null, requestRels);
 
     if (!topic) {
         return this._sendError(req, res, next, 400, 'Bad Request');

--- a/test/pubsubhubbub-test.js
+++ b/test/pubsubhubbub-test.js
@@ -81,6 +81,22 @@ describe('pubsubhubbub notification', function() {
 		});
 	});
 
+	it('should return 204 (without quotations on the rel) - successful request', function (done) {
+		var options = {
+			url: 'http://localhost:8000',
+			headers: {
+				'X-Hub-Signature': 'sha1='+hub_encryption,
+				'link': '<http://test.com>; rel=self, <http://pubsubhubbub.appspot.com/>; rel=hub',
+			},
+			body: response_body
+		}
+		
+		request.post(options, function (err, res, body) {
+			expect(res.statusCode).to.equal(204);
+			done();
+		});
+	})
+
 	it('should emit a feed event - successful request', function(done) {
 		var eventFired = false;
 		var options = {

--- a/test/pubsubhubbub-test.js
+++ b/test/pubsubhubbub-test.js
@@ -89,13 +89,13 @@ describe('pubsubhubbub notification', function() {
 				'link': '<http://test.com>; rel=self, <http://pubsubhubbub.appspot.com/>; rel=hub',
 			},
 			body: response_body
-		}
+		};
 		
-		request.post(options, function (err, res, body) {
+		request.post(options, function (err, res) {
 			expect(res.statusCode).to.equal(204);
 			done();
 		});
-	})
+	});
 
 	it('should emit a feed event - successful request', function(done) {
 		var eventFired = false;


### PR DESCRIPTION
The following example wasn't being detected, by the regex responsible for setting the topic and hub variables on the _onPostRequest method. This caused the lib to return 400, although it's a valid link.

Example:
'http://test.com; rel=self, http://pubsubhubbub.appspot.com/; rel=hub'

I've added a test as well, so in the future, the situation explained above can be avoided.